### PR TITLE
Admin event listener pagerduty + Require role authenticator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ nbproject
 *.exe
 *.o
 *.so
-
+/keycloak-12.0.0-SNAPSHOT
 # Packages #
 ############
 # it's better to unpack these files and commit the raw source

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/RequireRoleAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/RequireRoleAuthenticator.java
@@ -1,0 +1,53 @@
+package org.keycloak.authentication.authenticators.browser;
+
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
+
+public class RequireRoleAuthenticator implements Authenticator {
+    @Override
+    public boolean requiresUser() {
+        return true;
+    }
+
+    @Override
+    public void authenticate(AuthenticationFlowContext context) {
+        UserModel user = context.getUser();
+        RealmModel realm = context.getRealm();
+        AuthenticatorConfigModel authConfig = context.getAuthenticatorConfig();
+        if(user != null && authConfig!=null && authConfig.getConfig()!=null){
+            String requiredRole = authConfig.getConfig().get(RequireRoleAuthenticatorFactory.CONDITIONAL_USER_ROLE);
+            RoleModel role = KeycloakModelUtils.getRoleFromString(realm, requiredRole);
+            if (user.hasRole(role)) {
+                context.success();
+                return;
+            }
+        }
+        context.failure(AuthenticationFlowError.INVALID_USER);
+    }
+
+    @Override
+    public void action(AuthenticationFlowContext context) {
+
+    }
+
+    @Override
+    public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+        return true;
+    }
+
+    @Override
+    public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/RequireRoleAuthenticatorFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/RequireRoleAuthenticatorFactory.java
@@ -1,0 +1,96 @@
+package org.keycloak.authentication.authenticators.browser;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.AuthenticationExecutionModel.Requirement;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+
+import java.util.Collections;
+import java.util.List;
+
+public class RequireRoleAuthenticatorFactory implements AuthenticatorFactory {
+    public static final String PROVIDER_ID = "auth-require-role";
+    static RequireRoleAuthenticator SINGLETON = new RequireRoleAuthenticator();
+    protected static final String CONDITIONAL_USER_ROLE = "condUserRole";
+
+    private static List<ProviderConfigProperty> commonConfig;
+
+    static {
+        commonConfig = Collections.unmodifiableList(ProviderConfigurationBuilder.create()
+            .property().name(CONDITIONAL_USER_ROLE).label("User role")
+            .helpText("Role the user should have to execute this flow. Click 'Select Role' button to browse roles, or just type it in the textbox. To specify an application role the syntax is appname.approle, i.e. myapp.myrole")
+            .type(ProviderConfigProperty.ROLE_TYPE).add()
+            .build()
+        );
+    }
+
+    @Override
+    public Authenticator create(KeycloakSession session) {
+        return SINGLETON;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getReferenceCategory() {
+        return "authentication";
+    }
+
+    @Override
+    public boolean isConfigurable() {
+        return true;
+    }
+
+    private static final Requirement[] REQUIREMENT_CHOICES = {
+        AuthenticationExecutionModel.Requirement.REQUIRED, AuthenticationExecutionModel.Requirement.DISABLED
+    };
+
+    @Override
+    public Requirement[] getRequirementChoices() {
+        return REQUIREMENT_CHOICES;
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "Require Role";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Validates that the user has the required role";
+    }
+
+    @Override
+    public boolean isUserSetupAllowed() {
+        return false;
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return commonConfig;
+    }
+
+}

--- a/services/src/main/java/org/keycloak/events/admin/AdminEventListenerProvider.java
+++ b/services/src/main/java/org/keycloak/events/admin/AdminEventListenerProvider.java
@@ -1,0 +1,71 @@
+package org.keycloak.events.admin;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import org.jboss.logging.Logger;
+import org.keycloak.events.Event;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.util.JsonSerialization;
+import org.keycloak.events.admin.helpers.ApiConnectionHelper;
+
+public class AdminEventListenerProvider implements EventListenerProvider {
+
+    private final Logger log;
+    private RealmModel realm;
+    private final KeycloakSession session;
+    private ApiConnectionHelper httpHelper;
+     
+    public AdminEventListenerProvider(KeycloakSession session, Logger log) {
+        this.session = session;
+        this.log = log;
+        this.realm = session.getContext().getRealm();
+        this.httpHelper = new ApiConnectionHelper();   
+    }
+
+    @Override
+    public void onEvent(AdminEvent adminEvent, boolean b) {
+        log.info("## NEW ADMIN EVENT ##");
+        log.info("-----------------------------------------------------------");
+        log.info("Resource pathdd" + ": " + adminEvent.getResourcePath());
+        log.info("Resource type" + ": " + adminEvent.getResourceType());
+        log.info("Operation type" + ": " + adminEvent.getOperationType());
+        log.info("-----------------------------------------------------------");
+        if(adminEvent.getResourceType().equals(ResourceType.USER)
+         && adminEvent.getOperationType().equals(OperationType.DELETE)){
+            try {
+                UserRepresentation user = JsonSerialization.readValue(
+                    new ByteArrayInputStream(adminEvent.getRepresentation().getBytes()),
+                    new TypeReference<UserRepresentation>() {
+                });
+                for (Map.Entry<String, List<String>> entry : user.getAttributes().entrySet()) {
+                    if(entry.getKey() == "pagerduty"){
+                        this.httpHelper.deleteExternalUser(user.getEmail(), "pagerduty");
+                    }
+                    for(String item : entry.getValue()){
+                        log.info(item);
+                    }
+                }                
+            } catch (IOException ioe) {
+                throw new RuntimeException(ioe);
+            }
+        } 
+    }
+
+    @Override
+    public void onEvent(Event event) {
+        // No action required on non-admin events
+    }
+
+    @Override
+    public void close() {
+        // Nothing to close
+    }
+}

--- a/services/src/main/java/org/keycloak/events/admin/AdminEventListenerProvider.java
+++ b/services/src/main/java/org/keycloak/events/admin/AdminEventListenerProvider.java
@@ -47,7 +47,7 @@ public class AdminEventListenerProvider implements EventListenerProvider {
                 });
                 for (Map.Entry<String, List<String>> entry : user.getAttributes().entrySet()) {
                     if(entry.getKey() == "pagerduty"){
-                        this.httpHelper.deleteExternalUser(user.getEmail(), "pagerduty");
+                        log.info(this.httpHelper.deleteExternalUser(user.getEmail(), "pagerduty"));
                     }
                     for(String item : entry.getValue()){
                         log.info(item);

--- a/services/src/main/java/org/keycloak/events/admin/AdminEventListenerProviderFactory.java
+++ b/services/src/main/java/org/keycloak/events/admin/AdminEventListenerProviderFactory.java
@@ -1,4 +1,4 @@
-  
+
 package org.keycloak.events.admin;
 
 import org.keycloak.Config;
@@ -6,9 +6,15 @@ import org.keycloak.events.EventListenerProviderFactory;
 import org.keycloak.events.EventListenerProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ServerInfoAwareProviderFactory;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import org.jboss.logging.Logger;
 
-public class AdminEventListenerProviderFactory implements EventListenerProviderFactory {
+public class AdminEventListenerProviderFactory implements EventListenerProviderFactory,
+    ServerInfoAwareProviderFactory {
 
     private static final Logger log = Logger.getLogger("org.keycloak.events");
 
@@ -35,5 +41,12 @@ public class AdminEventListenerProviderFactory implements EventListenerProviderF
     @Override
     public String getId() {
         return "admin-listener";
+    }
+
+    @Override
+    public Map<String, String> getOperationalInfo() {
+        Map<String, String> ret = new LinkedHashMap<>();
+        ret.put("Admin Event Listener", "It provides triggers that manage users on external systems. F.x: A users that gets deleted on Keycloak also gets deleted on PagerDuty");
+        return ret;
     }
 }

--- a/services/src/main/java/org/keycloak/events/admin/AdminEventListenerProviderFactory.java
+++ b/services/src/main/java/org/keycloak/events/admin/AdminEventListenerProviderFactory.java
@@ -1,0 +1,39 @@
+  
+package org.keycloak.events.admin;
+
+import org.keycloak.Config;
+import org.keycloak.events.EventListenerProviderFactory;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.jboss.logging.Logger;
+
+public class AdminEventListenerProviderFactory implements EventListenerProviderFactory {
+
+    private static final Logger log = Logger.getLogger("org.keycloak.events");
+
+    @Override
+    public EventListenerProvider create(KeycloakSession session) {
+        return new AdminEventListenerProvider(session, log);
+    }
+
+    @Override
+    public void init(Config.Scope scope) {
+        //
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory keycloakSessionFactory) {
+        //
+    }
+
+    @Override
+    public void close() {
+        //
+    }
+
+    @Override
+    public String getId() {
+        return "admin-listener";
+    }
+}

--- a/services/src/main/java/org/keycloak/events/admin/helpers/ApiConnectionHelper.java
+++ b/services/src/main/java/org/keycloak/events/admin/helpers/ApiConnectionHelper.java
@@ -1,0 +1,82 @@
+package org.keycloak.events.admin.helpers;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+
+import org.keycloak.events.admin.helpers.pagerduty.Users;
+
+public class ApiConnectionHelper {
+    private String pagerdutyUrl = "https://api.pagerduty.com/users";
+		
+		//convert json string to object
+		
+    public String deleteExternalUser(String userEmail, String service) {
+        if(service == "pagerduty"){
+            return deletePagerDutyUser(userEmail);
+        }
+        return "No user-deletion follow-up trigger for SP: "+service;
+    }
+
+    private String deletePagerDutyUser(String userEmail){
+        HttpURLConnection httpClient = null;
+        try {
+            httpClient = (HttpURLConnection) new URL(pagerdutyUrl+"?query="+userEmail)
+                .openConnection();
+
+            //GET REQUEST FETCHING USER IDs
+            httpClient.setRequestMethod("GET");
+            httpClient.setRequestProperty("User-Agent", "Mozilla/5.0");
+            httpClient.setRequestProperty("Accept", "application/vnd.pagerduty+json;version=2");
+            httpClient.setRequestProperty("Content-Type", "application/json");
+            httpClient.setRequestProperty("Authorization", System.getenv("pagerduty_token"));
+
+            BufferedReader in = new BufferedReader(new InputStreamReader(httpClient.getInputStream()));
+            StringBuilder response = new StringBuilder();
+            String line;
+
+            while ((line = in.readLine()) != null) {
+                response.append(line);
+            }
+            
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            mapper.configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false);
+            mapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+            String jsonResponse = response.toString();
+            Users userList = mapper.readValue(jsonResponse, Users.class);
+            
+            String userId = userList.getUsers().get(0).getId();
+            
+            //DELETE REQUEST
+            httpClient = (HttpURLConnection) new URL(pagerdutyUrl+"/"+userId).openConnection();
+
+            httpClient.setRequestMethod("DELETE");
+            httpClient.setRequestProperty("User-Agent", "Mozilla/5.0");
+            httpClient.setRequestProperty("Accept", "application/vnd.pagerduty+json;version=2");
+            httpClient.setRequestProperty("Content-Type", "application/json");
+            httpClient.setRequestProperty("Authorization", System.getenv("pagerduty_token"));
+            in = new BufferedReader(new InputStreamReader(httpClient.getInputStream()));
+            response = new StringBuilder();
+
+            while ((line = in.readLine()) != null) {
+                response.append(line);
+            }
+
+            return response.toString();
+        }
+        catch(IOException io){  
+            return  io.toString();
+        }
+        finally {
+            if (httpClient != null) {
+                httpClient.disconnect();
+            }
+        }   
+    }
+}

--- a/services/src/main/java/org/keycloak/events/admin/helpers/pagerduty/User.java
+++ b/services/src/main/java/org/keycloak/events/admin/helpers/pagerduty/User.java
@@ -1,0 +1,34 @@
+package org.keycloak.events.admin.helpers.pagerduty;
+//import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class User {
+    
+    private String id;
+
+    private String name;
+
+    private String email;
+
+    public String getId(){
+        return this.id;
+    }
+    public String getName(){
+        return this.name;
+    }
+    public String getEmail(){
+        return this.email;
+    }
+
+    public void setId(String id){
+        this.id = id;
+    } 
+    public void setName(String name){
+        this.name = name;
+    }
+    public void setEmail(String email){
+        this.email = email;
+    }
+
+    public User() {
+    }
+}

--- a/services/src/main/java/org/keycloak/events/admin/helpers/pagerduty/Users.java
+++ b/services/src/main/java/org/keycloak/events/admin/helpers/pagerduty/Users.java
@@ -1,0 +1,20 @@
+package org.keycloak.events.admin.helpers.pagerduty;
+
+//import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+
+public class Users {
+
+    private ArrayList<User> users;
+
+    public ArrayList<User> getUsers(){
+        return this.users;
+    }
+
+    public void setUsers(ArrayList<User> users){
+        this.users = users;
+    }
+
+    public Users() {
+    }
+}

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -559,10 +559,10 @@ public class UserResource {
     @NoCache
     public Response deleteUser() {
         auth.users().requireManage(user);
-
+        UserRepresentation rep = this.getUser();
         boolean removed = new UserManager(session).removeUser(realm, user);
         if (removed) {
-            adminEvent.operation(OperationType.DELETE).resourcePath(session.getContext().getUri()).success();
+            adminEvent.operation(OperationType.DELETE).resourcePath(session.getContext().getUri()).representation(rep).success();
             return Response.noContent().build();
         } else {
             return ErrorResponse.error("User couldn't be deleted", Status.BAD_REQUEST);

--- a/services/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -49,3 +49,4 @@ org.keycloak.authentication.authenticators.challenge.BasicAuthOTPAuthenticatorFa
 org.keycloak.authentication.authenticators.challenge.NoCookieFlowRedirectAuthenticatorFactory
 org.keycloak.authentication.authenticators.browser.WebAuthnAuthenticatorFactory
 org.keycloak.authentication.authenticators.browser.WebAuthnPasswordlessAuthenticatorFactory
+org.keycloak.authentication.authenticators.browser.RequireRoleAuthenticatorFactory

--- a/services/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
@@ -17,3 +17,4 @@
 
 org.keycloak.events.email.EmailEventListenerProviderFactory
 org.keycloak.events.log.JBossLoggingEventListenerProviderFactory
+org.keycloak.events.admin.AdminEventListenerProviderFactory


### PR DESCRIPTION
## Features:
### Admin Event Listenner
An event listener that executes the deletion of users on PagerDuty when they are deleted on Keycloak, this is done by sending a request to the PagerDuty API. The implementation is a standard [Keycloak SPI](https://www.keycloak.org/docs/latest/server_development/index.html#_auth_spi) with a helper class to handle API requests.

### Require Role Authenticator
Custom authenticator that allows creating auth flows that require users to have certain roles in order to gain access to certain services, f.x. a user needs to have a role of "newrelic_user" in order to login to New Relic. It's implemented using Keycloak's default [Authentication SPI](https://www.keycloak.org/docs/latest/server_development/index.html#_events).

### Risks:
- Will making requests to an external API expose Keycloak to any vulnerabilities?
- Is setting the API key as a environment variable expose it?
- May the admin accidentally delete an user on another system? (not really, cause the admin will have first to assign an attribute named "pagerduty" to the user, and may remove it without any side effects)