### PR TITLE
Added role expiration date feature

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/RequireRoleAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/RequireRoleAuthenticator.java
@@ -9,8 +9,12 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
+import java.util.Date;
+import java.text.SimpleDateFormat;
+import org.jboss.logging.Logger;
 
 public class RequireRoleAuthenticator implements Authenticator {
+    private final Logger log = Logger.getLogger("org.keycloak.events");
     @Override
     public boolean requiresUser() {
         return true;
@@ -24,12 +28,31 @@ public class RequireRoleAuthenticator implements Authenticator {
         if(user != null && authConfig!=null && authConfig.getConfig()!=null){
             String requiredRole = authConfig.getConfig().get(RequireRoleAuthenticatorFactory.CONDITIONAL_USER_ROLE);
             RoleModel role = KeycloakModelUtils.getRoleFromString(realm, requiredRole);
+            user = removeExpiredRole(requiredRole, user, role);
             if (user.hasRole(role)) {
                 context.success();
                 return;
             }
         }
         context.failure(AuthenticationFlowError.INVALID_USER);
+    }
+    
+    private UserModel removeExpiredRole(String requiredRole, UserModel user, RoleModel role){
+        Date today = new Date();
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd");
+        sdf.setLenient(false);
+        try{
+            for(String attribute : user.getAttribute(requiredRole)){
+                Date expirationDate = sdf.parse(attribute);
+                if(today.compareTo(expirationDate) >= 0){
+                    user.deleteRoleMapping(role);
+                    user.removeAttribute(requiredRole);
+                }
+            }
+        }catch(Exception e){
+           log.error(e.getMessage());
+        }
+        return user;
     }
 
     @Override


### PR DESCRIPTION
## Role Expiration feature
In order to implement a feature that allows an admin give temporary access to a certain **Service Provider** to an user, role expiration date feature was implemented. This feature is based on the already existing attributes a user can have:
![image](https://user-images.githubusercontent.com/71074725/95998774-94def180-0e0b-11eb-8a18-7e4fa367a63e.png)
Each attribute stores a key-value pair that can be used for any purpose within the application. In order to add an expiration date to a role the user already have and need to access a Service, you only need to add a date in the future in the **"yyyy/mm/dd"** format value to a key equal to the role you want to be temporary.
So, for an example, if you want to make so the pager_duty role expires on 2020/11/29, you will simply make sure that the user has an attribute of pager_duty equal to 2020/11/29 (make sure you hit the add AND the **save** buttons):
![image](https://user-images.githubusercontent.com/71074725/96000244-14b98b80-0e0d-11eb-8bf1-2efb54a4fce7.png)
Once that is set, when the user tries to login after 2020/11/29 it will get the pager_duty role removed, what will make logging into Pager Duty impossible. Admin can assign the role to that user again if necessary.

### Dependencies:
- This feature depends on and sits on top of the Require Role feature. Require Role feature can be configured as part of the authentication flow of a Service Provider. This give it flexibility, as it can only be used for Services where Require Role is configured (which right now is all of them), but also dependability, so you can't set temporary access without a role (what wouldn't make sense anyway).